### PR TITLE
Require cytoolz

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fc9c3a7b27bd2f76aead3016ff147d80396dfa147e1be92a732d836a99817254
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - dask-scheduler=distributed.cli.dask_scheduler:go
     - dask-ssh=distributed.cli.dask_ssh:go

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - python
     - click >=6.6
     - cloudpickle >=0.2.2
+    - cytoolz >=0.7.4
     - dask-core >=0.17.0
     - futures  # [py2k]
     - msgpack-python


### PR DESCRIPTION
Fixes https://github.com/conda-forge/distributed-feedstock/issues/37

Adds `cytoolz` as a required dependency. Technically only `toolz` is required. However this is a nice optional dependency that offers a speedup over `toolz` and is easy for us to provide.