### PR TITLE
Bump version to 2021.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.4.1" %}
+{% set version = "2021.5.0" %}
 
 package:
   name: distributed
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/distributed/distributed-{{ version }}.tar.gz
-  sha256: 4c1b189ec5aeaf770c473f730f4a3660dc655601abd22899e8a0662303662168
+  sha256: 4da09db7972120db0a8e7fc2b2f91bb4d952ce21b185ccc1356603613060a0b3
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - dask-scheduler=distributed.cli.dask_scheduler:go
     - dask-ssh=distributed.cli.dask_ssh:go
@@ -27,10 +27,10 @@ requirements:
 
   run:
     - python
-    - click >=6.6,<8.0.0
+    - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core >=2021.03.0
+    - dask-core {{ version }}
     - msgpack-python >=0.6.0
     - psutil >=5.0
     - pyyaml


### PR DESCRIPTION
This PR adds `distributed=2021.5.0`

Closes https://github.com/conda-forge/distributed-feedstock/issues/166

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
