### PR TITLE
Tighten `dask-core` pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core =={{ version }}
+    - dask-core ={{ version }},!={{ version }}a.*
     - jinja2
     - locket >=1.0.0
     - msgpack-python >=0.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core ={{ version }},!={{ version }}a.*
+    - dask-core ={{ version }},!={{ version }}a*
     - jinja2
     - locket >=1.0.0
     - msgpack-python >=0.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8fae2fbd6dea304a169c14eb21066743fe5eea7564903a07b43144c294c79456
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -27,7 +27,7 @@ requirements:
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core {{ version }}
+    - dask-core =={{ version }}
     - jinja2
     - locket >=1.0.0
     - msgpack-python >=0.6.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
As part of addressing https://github.com/dask/dask/issues/9367, this PR tightens the pinning of the `dask-core` dependency so that we can only pull in packages with an exact version match, preventing us from erroneously pulling in nightly packages.

cc @galipremsagar

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
