### PR TITLE
Fix `dask-core` pinning to properly exclude nightlies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8fae2fbd6dea304a169c14eb21066743fe5eea7564903a07b43144c294c79456
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -27,7 +27,7 @@ requirements:
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core ={{ version }},!={{ version }}a*
+    - dask-core {{ version }}.*,!={{ version }}a.*
     - jinja2
     - locket >=1.0.0
     - msgpack-python >=0.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,13 @@ requirements:
   host:
     - python >=3.8
     - pip
+    - dask-core {{ version }}
   run:
     - python >=3.8
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core {{ version }}.*,!={{ version }}a.*
+    - {{ pin_compatible('dask-core', max_pin='x.x.x') }}
     - jinja2
     - locket >=1.0.0
     - msgpack-python >=0.6.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
As brought up in https://github.com/conda-forge/dask-feedstock/pull/190#issuecomment-1215624680, the pinning introduced in #217 accidentally blocked the security backport proposal - tested this new pinning out locally and it seems to work with backports while also blocking nightly packages.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
